### PR TITLE
Fix setterm error when using non-interactive shell logins

### DIFF
--- a/upstream/custom.sh
+++ b/upstream/custom.sh
@@ -1,5 +1,5 @@
-#Turn off annoying blinking
-setterm -blength 0
+#Turn off annoying blinking if interactive
+tty -s && setterm -blength 0
 
 #Set aliases
 alias cp='cp -i'


### PR DESCRIPTION
Fix setterm error when using scp or other non-interactive logins
