### PR TITLE
Replace parse-git-branch.sh with git-prompt.sh

### DIFF
--- a/build/korora-extras.spec
+++ b/build/korora-extras.spec
@@ -40,7 +40,6 @@ install -m 0755 %{_builddir}/%{name}-%{version}/fstrim %{buildroot}%{_sysconfdir
 install -m 0755 %{_builddir}/%{name}-%{version}/vimrc %{buildroot}%{_sysconfdir}/skel/.vimrc
 #cp -a %{_builddir}/%{name}-%{version}/01_korora %{buildroot}%{_sysconfdir}/sudoers.d/
 install -m 0755 %{_builddir}/%{name}-%{version}/custom.sh %{buildroot}%{_sysconfdir}/profile.d/custom.sh
-install -m 0755 %{_builddir}/%{name}-%{version}/parse-git-branch.sh %{buildroot}%{_bindir}/parse-git-branch.sh
 #install -m 0440 %{_builddir}/%{name}-%{version}/01_korora %{buildroot}%{_sysconfdir}/sudoers.d/01_korora
 #cp -a %{_builddir}/%{name}-%{version}/*sh %{buildroot}%{_bindir}/
 #removing this custom.sh because this goes under profile.d instead and I was lazy above and copied all shell scripts to bin

--- a/upstream/custom.sh
+++ b/upstream/custom.sh
@@ -1,3 +1,6 @@
+# Source for git information in prompt
+source /usr/share/doc/git/contrib/completion/git-prompt.sh
+
 #Turn off annoying blinking if interactive
 tty -s && [ $TERM != "xterm" ] && setterm --blength 0 2>/dev/null
 
@@ -17,8 +20,8 @@ alias which='alias | /usr/bin/which --tty-only --read-alias --show-dot --show-ti
 #Set terminal colours
 if [ ${EUID} -eq 0 ] ; then
 	#red and # prompt
-  export PS1="\[\033[0;34m\][\$(date +%H:%M)] \[\033[0;31m\]\u\[\033[0;36m\]@\[\033[0;31m\]\h\[\033[0;34m\] \W\[\033[0;32m\]\$(parse-git-branch.sh) \[\033[0;34m\]#\[\033[00m\] "
+  export PS1="\[\033[0;34m\][\$(date +%H:%M)] \[\033[0;31m\]\u\[\033[0;36m\]@\[\033[0;31m\]\h\[\033[0;34m\] \W\[\033[0;32m\]\$(__git_ps1 \" (%s)\") \[\033[0;34m\]#\[\033[00m\] "
 else
 	#green and $ prompt
-  export PS1="\[\033[0;34m\][\$(date +%H:%M)] \[\033[0;32m\]\u\[\033[0;36m\]@\[\033[0;32m\]\h\[\033[0;34m\] \W\[\033[0;32m\]\$(parse-git-branch.sh) \[\033[0;34m\]$\[\033[00m\] "
+  export PS1="\[\033[0;34m\][\$(date +%H:%M)] \[\033[0;32m\]\u\[\033[0;36m\]@\[\033[0;32m\]\h\[\033[0;34m\] \W\[\033[0;32m\]\$(__git_ps1 \" (%s)\") \[\033[0;34m\]$\[\033[00m\] "
 fi

--- a/upstream/custom.sh
+++ b/upstream/custom.sh
@@ -1,5 +1,12 @@
 # Source for git information in prompt
-source /usr/share/doc/git/contrib/completion/git-prompt.sh
+if [ -f /usr/share/doc/git/contrib/completion/git-prompt.sh ]; then
+  source /usr/share/doc/git/contrib/completion/git-prompt.sh
+else
+  __git_ps1
+  {
+    : # Git is not installed so stub out function
+  }
+fi
 
 #Turn off annoying blinking if interactive
 tty -s && [ $TERM != "xterm" ] && setterm --blength 0 2>/dev/null

--- a/upstream/parse-git-branch.sh
+++ b/upstream/parse-git-branch.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
-


### PR DESCRIPTION
 git-prompt.sh provides more options for status information.

For example:
> ...if you set GIT_PS1_SHOWDIRTYSTATE to a nonempty value, unstaged (*) and staged (+) changes will be shown next to the branch name.

[15:09] lithrem@pc prompt-test (master) $ export GIT_PS1_SHOWDIRTYSTATE=1
[15:10] lithrem@pc prompt-test (master) $ echo "test" > test1.txt 
[15:10] lithrem@pc prompt-test (master *) $ git add test1.txt 
[15:11] lithrem@pc prompt-test (master +) $

More information can be found in /usr/share/doc/git/contrib/completion/git-prompt.sh
