### PR TITLE
Fixed: error message on bash " _gitps1: command not found"

### DIFF
--- a/upstream/custom.sh
+++ b/upstream/custom.sh
@@ -13,7 +13,7 @@ if [ -f /usr/share/git-core/contrib/completion/git-prompt.sh ]; then
   GIT_PS1_DESCRIBE_STYLE=default
 #  GIT_PS1_SHOWCOLORHINTS=1
 else
-  __git_ps1
+  __git_ps1()
   {
     : # Git is not installed so stub out function
   }


### PR DESCRIPTION
Fix issue with prompt when git is not installed, reported here:
https://kororaproject.org/support/engage/question/ralink-bluetooth-3290-and-mts-mblaze-ultra-mobile-broadband-dont-work-1