### PR TITLE
Only apply custom.sh to the environment if the shell is interactive

### DIFF
--- a/upstream/custom.sh
+++ b/upstream/custom.sh
@@ -1,7 +1,8 @@
-# only run this for bash
+# only run this for interactive bash
 if [ "$BASH" != "$(which bash)" -a "$BASH" != "/bin/bash" -a "$BASH" != "/usr/bin/bash" ]; then
   return
 fi
+tty -s || return
 
 # Source for git information in prompt
 if [ -f /usr/share/git-core/contrib/completion/git-prompt.sh ]; then
@@ -20,7 +21,7 @@ else
 fi
 
 #Turn off annoying blinking if interactive
-tty -s && [ $TERM != "xterm" ] && setterm --blength 0 2>/dev/null
+[ $TERM != "xterm" ] && setterm --blength 0 2>/dev/null
 
 #Set aliases
 alias cp='cp -i'


### PR DESCRIPTION
Newer custom.sh profile settings cause a number of tput errors when loaded in a non-interactive shell. For example when using scp to copy files from a K23 machine all the tput commands throw the following error:
```
tput: No value for $TERM and no -T specified
```
This PR adds a return very early on if the shell is not interactive.