### PR TITLE
Include hostname in prompt if you are root

### DIFF
--- a/upstream/korora.sh
+++ b/upstream/korora.sh
@@ -64,7 +64,7 @@ else
 fi
 
 # Check if we're local or remote or root
-if [[ -n "${SSH_CLIENT}" || -n "${SSH_TTY}" || "${USER}" == root ]] ; then
+if [[ -n "${SSH_CLIENT}" || -n "${SSH_TTY}" || ${EUID} -eq 0 ]] ; then
   # Prompt with hostname
   export PS1="\[${RESET}\][\[${BASE0}\]\A\[${RESET}\] \[${USER_COLOUR}\]\u@\h \[${CYAN}\]\w\[${YELLOW}\]\$(__git_ps1 \" (%s)\")\[${RESET}\]]\\$\[${RESET}\] "
 else

--- a/upstream/korora.sh
+++ b/upstream/korora.sh
@@ -63,8 +63,8 @@ else
   USER_COLOUR="${GREEN}"
 fi
 
-# Check if we're local or remote
-if [[ -n "${SSH_CLIENT}" || -n "${SSH_TTY}" ]] ; then
+# Check if we're local or remote or root
+if [[ -n "${SSH_CLIENT}" || -n "${SSH_TTY}" || "${USER}" == root ]] ; then
   # Prompt with hostname
   export PS1="\[${RESET}\][\[${BASE0}\]\A\[${RESET}\] \[${USER_COLOUR}\]\u@\h \[${CYAN}\]\w\[${YELLOW}\]\$(__git_ps1 \" (%s)\")\[${RESET}\]]\\$\[${RESET}\] "
 else


### PR DESCRIPTION
The ```${SSH_CLIENT}``` and ```${SSH_TTY}``` env variables do not always persist when you switch to root, e.g. when running ```sudo -i```.

This PR adds ```"${USER}" == root``` to the "include hostname" check. The downside is that the hostname is always included for root whether or not you are local or remote. Given the potential to run a command as root on the wrong host by accident, this feels like a small price to pay.