### PR TITLE
Add yaml to source file types

### DIFF
--- a/upstream/dircolors.ansi-universal
+++ b/upstream/dircolors.ansi-universal
@@ -241,6 +241,8 @@ EXEC 01;31  # Unix
 .js 32
 .coffee 32
 .man 32
+.yml 32
+.yaml 32
 .0 32
 .1 32
 .2 32


### PR DESCRIPTION
Poor old yaml has been missing out on being coloured the same as other
text file types in the shell. Well, suffer no more yaml! You are now a
first class shell citizen.